### PR TITLE
Removed submitterId from required fields

### DIFF
--- a/src/registry_schemas/schemas/comment.json
+++ b/src/registry_schemas/schemas/comment.json
@@ -13,15 +13,13 @@
                 {
                     "required": [
                         "comment",
-                        "filingId",
-                        "submitterId"
+                        "filingId"
                     ]
                 },
                 {
                     "required": [
                         "comment",
-                        "businessId",
-                        "submitterId"
+                        "businessId"
                     ]
                 }
             ],


### PR DESCRIPTION
*Issue #:* /bcgov/entity#2613

*Description of changes:*
Removed submitterId from required fields. This is set by API during POST, not sent from UI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
