### PR TITLE
Corrections schema - minor fix plus two new attributes for completed filing

### DIFF
--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -334,6 +334,7 @@ CORRECTION_AR = {
             'certifiedBy': 'full name',
             'email': 'no_one@never.get',
             'date': '2020-02-18',
+            'affectedFilings': [101, ],
             'routingSlipNumber': '123456789'
         },
         'business': {
@@ -346,7 +347,7 @@ CORRECTION_AR = {
             'legalType': 'CP'
         },
         'correction': {
-            'correctedFilingId': 0,
+            'correctedFilingId': 101,
             'correctedFilingType': 'annualReport',
             'correctedFilingDate': '2019-04-08',
             'comment': "User selected wrong agm date. ACTION ITEMS: change agm date to '2018-07-23'."

--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -840,8 +840,8 @@ STUB_FILING = {
 }
 
 # build complete list of filings with names, for use in the generic test_valid_filing() test
-# - not including AR because it's already a complete filing rather than the others that are snippets without header and
-#   business elements; prepended to list afterwards.
+# - not including AR or correction because they are already complete filings rather than the others that are snippets
+# without header and business elements; prepended to list afterwards.
 FILINGS_WITH_TYPES = [
     ('changeOfDirectors', CHANGE_OF_DIRECTORS),
     ('changeOfAddress', CHANGE_OF_ADDRESS),
@@ -872,3 +872,4 @@ def _build_complete_filing(name, snippet):
 
 ALL_FILINGS = [_build_complete_filing(f[0], f[1]) for f in FILINGS_WITH_TYPES]
 ALL_FILINGS.insert(0, ANNUAL_REPORT)
+ALL_FILINGS.insert(0, CORRECTION_COA)

--- a/src/registry_schemas/schemas/correction.json
+++ b/src/registry_schemas/schemas/correction.json
@@ -8,7 +8,7 @@
     "type": "object",
     "title": "Correction Filing",
     "properties": {
-        "annualReport": {
+        "correction": {
             "type": "object",
             "required": [
                 "correctedFilingId",

--- a/src/registry_schemas/schemas/filing.json
+++ b/src/registry_schemas/schemas/filing.json
@@ -132,6 +132,17 @@
                                 "ERROR"
                             ]
                         },
+                        "affectedFilings": {
+                            "type": "array",
+                            "title": "List of affected filings (ids) from this filing.",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "isCorrected": {
+                            "type": "boolean",
+                            "title": "Has this filing been corrected?"
+                        },
                         "comments": {
                             "type": "array",
                             "title": "List of filing comments.",


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
Fixed typo in corrections schema; added correction schema to filings unit tests.
Added two new attributes for completed filing json output (for UI). From discussion of UI with Cameron.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
