### PR TITLE
Add Email To Party Schema

### DIFF
--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -803,6 +803,7 @@ INCORPORATION = {
                 'firstName': 'Joe',
                 'lastName': 'Swanson',
                 'middleName': 'P',
+                'email': 'joe@email.com',
                 'orgName': '',
                 'partyType': 'person'
             },

--- a/src/registry_schemas/schemas/party.json
+++ b/src/registry_schemas/schemas/party.json
@@ -30,6 +30,10 @@
                 "orgName": {
                     "type": "string",
                     "maxLength": 50
+                },
+                "email": {
+                    "type": "string",
+                    "format": "email"
                 }
             },
             "anyOf": [
@@ -54,7 +58,7 @@
             "type": "object",
             "properties": {
                 "roleType": {
-                    "enum": ["Director", "Incorporator", "Completing Party"]   
+                    "enum": ["Director", "Incorporator", "Completing Party"]
                 },
                 "appointmentDate": {
                     "type": "string",


### PR DESCRIPTION
*Issue #:* /bcgov/entity#3395

*Description of changes:*

* Added optional `Email` property to the `Person` schema which is a sub schema or the `Party` schema.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
