### PR TITLE
took name translation out of required for transition

### DIFF
--- a/src/registry_schemas/schemas/transition.json
+++ b/src/registry_schemas/schemas/transition.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/transition",
   "required": [
-    "nameTranslations",
     "offices",
     "parties",
     "shareStructure",

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.9.0'  # pylint: disable=invalid-name
+__version__ = '2.9.1'  # pylint: disable=invalid-name


### PR DESCRIPTION
Signed-off-by: Kial Jinnah <kialj876@gmail.com>

*Issue #:* /bcgov/entity#5238

*Description of changes:*
- took out name translation from required fields of transition filing
  - this is for cases where a business does not have any name translations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
