### PR TITLE
6417- Changed orderDate to be optional in courtOrder

### DIFF
--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -1122,7 +1122,7 @@ CORRECTION_INCORPORATION = {
 COURT_ORDER = {
     'fileNumber': '#1234-5678/90',
     'orderDate': '2021-01-30T09:56:01+08:00',
-    'effectOfOrder': 'Order to disclose financial data'
+    'effectOfOrder': 'planOfArrangement'
 }
 
 ALTERATION = {

--- a/src/registry_schemas/schemas/court_order.json
+++ b/src/registry_schemas/schemas/court_order.json
@@ -25,7 +25,6 @@
         }
     },
     "required": [
-        "fileNumber",
-        "orderDate"
+        "fileNumber"
     ]
 }

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.11.3'  # pylint: disable=invalid-name
+__version__ = '2.11.4'  # pylint: disable=invalid-name

--- a/tests/unit/test_alteration.py
+++ b/tests/unit/test_alteration.py
@@ -141,8 +141,8 @@ def test_validate_invalid_share_structure_alteration():
 
 
 @pytest.mark.parametrize('invalid_court_order', [
-    *[{'orderDate': '2021-01-30T09:56:01+08:00'}],
-    *[{'fileNumber': '12345'}],
+    *[{'orderDate': '2021-01-30T09:56:01+08:00',
+       'effectOfOrder': 'valid effect of order'}],
     *[{
         'fileNumber': invalid_file_number,
         'orderDate': '2021-01-30T09:56:01+08:00'
@@ -155,16 +155,7 @@ def test_validate_invalid_share_structure_alteration():
         'fileNumber': '12345',
         'orderDate': '2021-01-30T09:56:01+08:00',
         'effectOfOrder': invalid_effect_of_order
-    } for invalid_effect_of_order in ['abcd', ('01234567890123456789012345678901234567890123456789'
-                                               '01234567890123456789012345678901234567890123456789'
-                                               '01234567890123456789012345678901234567890123456789'
-                                               '01234567890123456789012345678901234567890123456789'
-                                               '01234567890123456789012345678901234567890123456789'
-                                               '01234567890123456789012345678901234567890123456789'
-                                               '01234567890123456789012345678901234567890123456789'
-                                               '01234567890123456789012345678901234567890123456789'
-                                               '01234567890123456789012345678901234567890123456789'
-                                               '012345678901234567890123456789012345678901234567890')]
+    } for invalid_effect_of_order in ['abcd', ('a' * 501)]  # long effectOfOrder
     ]
 ])
 def test_validate_invalid_court_orders(invalid_court_order):


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6417

*Description of changes:*

- Changed orderDate to be optional in courtOrder
- Updated tests
- Updated effectOfOrder example data

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
