### PR TITLE
6833 update filings schema definition to get court order fields validating

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 jsonschema
 requests
 strict-rfc3339
+more-itertools

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,3 +2,4 @@ flask
 jsonschema
 requests
 strict-rfc3339
+more-itertools

--- a/src/registry_schemas/constants.py
+++ b/src/registry_schemas/constants.py
@@ -1,0 +1,25 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Constants."""
+
+BASE_URI = 'https://bcrs.gov.bc.ca/.well_known/schemas'
+FILING_SCHEMA_ID = 'filing'
+FILING_KEY = 'filing'
+ALTERATION_KEY = 'alteration'
+HEADER_KEY = 'header'
+FILING_HEADER_KEY = 'filing_header'
+FILING_HEADER_NAME_KEY = 'name'
+DEFINITIONS_KEY = 'definitions'
+PROPERTIES_KEY = 'properties'
+ENUM_KEY = 'enum'

--- a/src/registry_schemas/flask/schema_services.py
+++ b/src/registry_schemas/flask/schema_services.py
@@ -67,7 +67,7 @@ class SchemaServices():
         :return: dict
         """
         if 'rsbc_filing_schema_store' not in g:
-            g.rsbc_filing_schema_store = get_schema_store()
+            g.rsbc_filing_schema_store = get_schema_store()  # pylint: disable=assigning-non-slot
 
         return g.rsbc_filing_schema_store
 

--- a/src/registry_schemas/schema_validation_info.py
+++ b/src/registry_schemas/schema_validation_info.py
@@ -1,0 +1,37 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SchemaValidationInfo stores info relevant to a specific schema validation.
+
+Created to provide an easier way to pass schema validation info to a
+validator and other areas of code which has a use for the schema
+validation info.
+"""
+
+BASE_URI = 'https://bcrs.gov.bc.ca/.well_known/schemas'
+
+
+class SchemaValidationInfo:  # pylint: disable=too-few-public-methods
+    """SchemaValidationInfo object."""
+
+    schema_id = None
+    schema_search_path = None
+    schema_store = None
+    validate_schema = False
+    schema_file_path = None
+    schema = None
+    resolver = None
+
+    def __init__(self, **attributes):
+        """__init__ method."""
+        self.__dict__.update(attributes)

--- a/src/registry_schemas/schema_validation_info.py
+++ b/src/registry_schemas/schema_validation_info.py
@@ -18,8 +18,6 @@ validator and other areas of code which has a use for the schema
 validation info.
 """
 
-BASE_URI = 'https://bcrs.gov.bc.ca/.well_known/schemas'
-
 
 class SchemaValidationInfo:  # pylint: disable=too-few-public-methods
     """SchemaValidationInfo object."""

--- a/src/registry_schemas/schema_validation_info_factory.py
+++ b/src/registry_schemas/schema_validation_info_factory.py
@@ -1,0 +1,53 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Factory class for retrieving schema validation related info."""
+
+from os import path
+
+from jsonschema import RefResolver
+
+from registry_schemas.schema_validation_info import SchemaValidationInfo
+
+
+BASE_URI = 'https://bcrs.gov.bc.ca/.well_known/schemas'
+
+
+class SchemaValidationInfoFactory:  # pylint: disable=too-few-public-methods
+    """SchemaValidationInfoFactory object."""
+
+    def __init__(self,
+                 schema_store: dict = None,
+                 validate_schema: bool = False,
+                 schema_search_path: str = None):
+        """Initialize SchemaValidationInfoFactory object."""
+        self._schema_search_path = schema_search_path
+        self._schema_store = schema_store
+        self._validate_schema = validate_schema
+        self._init()
+
+    def _init(self):
+        if not self._schema_search_path:
+            self._schema_search_path = path.join(path.dirname(__file__), 'schemas')
+
+    def get_schema_validation_info(self, schema_id: str):
+        """Get schema valiation info specific to a schema_id."""
+        schema = self._schema_store.get(f'{BASE_URI}/{schema_id}')
+        schema_file_path = path.join(self._schema_search_path, schema_id)
+        resolver = RefResolver(f'file://{schema_file_path}.json', schema, self._schema_store)
+        return SchemaValidationInfo(schema_id=schema_id,
+                                    schema_search_path=self._schema_search_path,
+                                    schema_store=self._schema_store,
+                                    validate_schema=self._validate_schema,
+                                    schema_file_path=schema_file_path,
+                                    schema=schema, resolver=resolver)

--- a/src/registry_schemas/schema_validation_info_factory.py
+++ b/src/registry_schemas/schema_validation_info_factory.py
@@ -24,7 +24,10 @@ BASE_URI = 'https://bcrs.gov.bc.ca/.well_known/schemas'
 
 
 class SchemaValidationInfoFactory:  # pylint: disable=too-few-public-methods
-    """SchemaValidationInfoFactory object."""
+    """SchemaValidationInfoFactory object.
+
+    Factory class to help with retrieving schema validation related info
+    """
 
     def __init__(self,
                  schema_store: dict = None,

--- a/src/registry_schemas/schemas/filing.json
+++ b/src/registry_schemas/schemas/filing.json
@@ -198,6 +198,18 @@
         }
       }
     },
+    "alteration_property": {
+      "$id": "#alteration_property",
+        "type": "object",
+        "required": [
+          "alteration"
+        ],
+        "properties": {
+          "alteration": {
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/alteration"
+          }
+        }
+    },
     "court_order_property": {
       "$id": "#court_order_property",
       "type": "object",
@@ -344,10 +356,10 @@
           "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/conversion"
         },
         {
-          "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/alteration"
+          "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/transition"
         },
         {
-          "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/transition"
+          "$ref": "#/definitions/alteration_property"
         }
       ]
     }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6833

Note: No schema tests were added for court order as parameterized tests already existed to cover invalid scenarios.

*Description of changes:*
* Refactored to support validation of the base filing schema and the filing type schema.  This was done by updating the logic in the `validate` method of `src/registry_schemas/utils.py` instead of the initial approach of triggering it via the schema definition with if/then conditions.  **_Note: this support for validation of the filing type schema has only been turned on for the `alterations` filing type.  As the stub filing currently allows almost any filing to pass schema validation given that it has a valid header and business property, turning this on for other untested filing types will likely break some things and require some testing._**
* Addition of itertools library.  Used `chain` method specifically to merge two error messages iterators
* Added `alteration_property` to definitions section of `filing.json` to enforce requirement of an `alteration` property for an alteration filing.  Before this change the filing schema was structured in such a way that the expected alteration filing would look like the following:
```
{
    'filing': {
        'header': {},
        'business': {},
        'nameRequest': {},
        'nameTranslations': [],
        'shareStructure': {},
        'contactPoint': {},
        ...
        'courtOrder': {}
    }
}
```
The alteration filing has been updated to the expected format of the following
```
{
    'filing': {
        'header': {},
        'business': {},
        'alteration': {
            'nameTranslations': [],
           'shareStructure': {},
           'contactPoint': {},
           ...
           'courtOrder': {}
        }
    }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
