### PR TITLE
fileNumber is not mandatory in registrars notation and order

### DIFF
--- a/src/registry_schemas/schemas/registrars_notation.json
+++ b/src/registry_schemas/schemas/registrars_notation.json
@@ -31,6 +31,6 @@
         }
     },
     "required": [
-        "fileNumber"
+        "orderDetails"
     ]
 }

--- a/src/registry_schemas/schemas/registrars_order.json
+++ b/src/registry_schemas/schemas/registrars_order.json
@@ -31,6 +31,6 @@
         }
     },
     "required": [
-        "fileNumber"
+        "orderDetails"
     ]
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#4392

*Description of changes:*
  - fileNumber is not mandatory in registrars notation and registrars order
  - orderDetails is mandatory in court order but we cannot set it as required here since court order is been used in alteration without orderDetails


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
