### PR TITLE
make courtOrder optional for alteration filing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ max_line_length=120
 notes=FIXME,XXX,TODO
 ignored-modules=
 ignored-classes=
-disable=C0301,W0511,R0801,R0902
+disable=C0301,W0511,W1514,R0801,R0902
 
 [isort]
 line_length=120

--- a/src/registry_schemas/schemas/alteration.json
+++ b/src/registry_schemas/schemas/alteration.json
@@ -33,13 +33,11 @@
                 },
                   "shareStructure": {
                     "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/share_structure"
+                },
+                  "courtOrder": {
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/court_order#/properties/courtOrder"
                 }
-            },
-            "anyOf": [
-                {
-                    "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/court_order"
-                }
-            ]
+            }
         }
     }
 }

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.15.1'  # pylint: disable=invalid-name
+__version__ = '2.15.3'  # pylint: disable=invalid-name

--- a/tests/unit/test_alteration.py
+++ b/tests/unit/test_alteration.py
@@ -56,7 +56,8 @@ def test_validate_valid_alteration_with_any_required_element():
     del alteration_json['provisionsRemoved']
     del alteration_json['nameTranslations']
     del alteration_json['shareStructure']
-    legal_filing = {'alteration': ALTERATION}
+    del alteration_json['courtOrder']
+    legal_filing = {'alteration': alteration_json}
 
     is_valid, errors = validate(legal_filing, 'alteration')
 

--- a/tests/unit/test_filings.py
+++ b/tests/unit/test_filings.py
@@ -362,7 +362,10 @@ def test_effective_date():
 
 def test_incorporation_filing_schema():
     """Assert that the JSONSchema validator is working."""
+    import json
     is_valid, errors = validate(INCORPORATION_FILING_TEMPLATE, 'filing')
+
+    f = json.dumps(INCORPORATION_FILING_TEMPLATE)
 
     if errors:
         for err in errors:


### PR DESCRIPTION
*Issue #:* n/a

*Description of changes:*
- make courtOrder optional for alteration filing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
