### PR TITLE
8933 Add affidavit and special resolution doc related properties to dissolution schema

### DIFF
--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -828,7 +828,11 @@ DISSOLUTION = {
             'postalCode': 'H0H0H0',
             'addressRegion': 'BC',
         }
-    }
+    },
+    'affidavitFileKey': '011e332d-1b8e-4218-8710-ad8ac1fbc592.pdf',
+    'affidavitFileName': 'affidavit_file.pdf',
+    'specialResolutionFileKey': '03c91f13-2f4d-4fe6-8792-8209723b20b6.pdf',
+    'specialResolutionFileName': 'special_resolution_file.pdf'
 }
 
 SPECIAL_RESOLUTION = {

--- a/src/registry_schemas/schemas/dissolution.json
+++ b/src/registry_schemas/schemas/dissolution.json
@@ -45,6 +45,22 @@
                 },
                 "custodialOffice": {
                     "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/office"
+                },
+                "affidavitFileKey": {
+                    "type": "string",
+                    "title": "The Identifier for affidavit file in file server"
+                },
+                "affidavitFileName": {
+                    "type": "string",
+                    "title": "The file name while uploading"
+                },
+                "specialResolutionFileKey": {
+                    "type": "string",
+                    "title": "The Identifier for special resolution file in file server"
+                },
+                "specialResolutionFileName": {
+                    "type": "string",
+                    "title": "The file name while uploading"
                 }
             }
         }

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.15.8'  # pylint: disable=invalid-name
+__version__ = '2.15.9'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8933

*Description of changes:*

* Add affidavit and special resolution doc related properties to dissolution schema  Note that none of the new properties added to the schema were required as only COOPs require affidavit and special resolution docs.  Required validation for these properties will be implemented in the legal api

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
