### PR TITLE
8914 Update dissolution and special resolution schemas

### DIFF
--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -837,9 +837,11 @@ SPECIAL_RESOLUTION = {
     'resolution': 'Be in resolved that cookies are delicious.\n\nNom nom nom...',
     'resolutionDate': '2021-01-10',
     'signingDate': '2021-01-10',
-    'signatoryFirstName': 'Jane',
-    'signatoryMiddleName': '',
-    'signatoryLastName': 'Doe'
+    'signatory': {
+        'firstName': 'Jane',
+        'middleName': '',
+        'lastName': 'Doe'
+    }
 }
 
 CHANGE_OF_NAME = {

--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -829,17 +829,17 @@ DISSOLUTION = {
             'addressRegion': 'BC',
         }
     },
-    'specialResolution': {
-        'resolution': 'vd resolution text...',
-        'resolutionFileKey': '03c91f13-2f4d-4fe6-8792-8209723b20b6.pdf',
-        'resolutionFileName': 'special_resolution_file.pdf'
-    },
     'affidavitFileKey': '011e332d-1b8e-4218-8710-ad8ac1fbc592.pdf',
     'affidavitFileName': 'affidavit_file.pdf'
 }
 
 SPECIAL_RESOLUTION = {
-    'resolution': 'Be in resolved that cookies are delicious.\n\nNom nom nom...'
+    'resolution': 'Be in resolved that cookies are delicious.\n\nNom nom nom...',
+    'resolutionDate': '2021-01-10',
+    'signingDate': '2021-01-10',
+    'signatoryFirstName': 'Jane',
+    'signatoryMiddleName': '',
+    'signatoryLastName': 'Doe'
 }
 
 CHANGE_OF_NAME = {

--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -838,9 +838,9 @@ SPECIAL_RESOLUTION = {
     'resolutionDate': '2021-01-10',
     'signingDate': '2021-01-10',
     'signatory': {
-        'firstName': 'Jane',
-        'middleName': '',
-        'lastName': 'Doe'
+        'givenName': 'Jane',
+        'additionalName': '',
+        'familyName': 'Doe'
     }
 }
 

--- a/src/registry_schemas/schemas/dissolution.json
+++ b/src/registry_schemas/schemas/dissolution.json
@@ -49,9 +49,6 @@
                 "custodialOffice": {
                     "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/office"
                 },
-                "specialResolution": {
-                    "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/special_resolution#/properties/specialResolution"
-                },
                 "affidavitFileKey": {
                     "type": "string",
                     "title": "The Identifier for affidavit file in file server"

--- a/src/registry_schemas/schemas/person.json
+++ b/src/registry_schemas/schemas/person.json
@@ -5,16 +5,17 @@
     "title": "Person Schema",
     "required": [],
     "properties": {
-        "firstName": {
+        "givenName": {
             "type": "string",
             "maxLength": 30
         },
-        "lastName": {
+        "familyName": {
             "type": "string",
             "maxLength": 30
         },
-        "middleName": {
+        "additionalName": {
             "type": "string",
+            "title": "An additional name for a Person, can be used for a middle name.",
             "maxLength": 30
         },
         "middleInitial": {

--- a/src/registry_schemas/schemas/person.json
+++ b/src/registry_schemas/schemas/person.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/person",
+    "type": "object",
+    "title": "Person Schema",
+    "required": [],
+    "properties": {
+        "firstName": {
+            "type": "string",
+            "maxLength": 30
+        },
+        "lastName": {
+            "type": "string",
+            "maxLength": 30
+        },
+        "middleName": {
+            "type": "string",
+            "maxLength": 30
+        },
+        "middleInitial": {
+            "type": "string",
+            "maxLength": 30
+        },
+        "email": {
+            "type": "string",
+            "format": "email"
+        }
+    }
+}

--- a/src/registry_schemas/schemas/special_resolution.json
+++ b/src/registry_schemas/schemas/special_resolution.json
@@ -19,15 +19,28 @@
                     "format": "date"
                 },
                 "resolution": {
-                    "type": "string"
-                },
-                "resolutionFileKey": {
                     "type": "string",
-                    "title": "The Identifier for special resolution file in file server"
+                    "maxLength": 1000
                 },
-                "resolutionFileName": {
+                "resolutionDate": {
                     "type": "string",
-                    "title": "The file name while uploading"
+                    "format": "date"
+                },
+                "signingDate": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "signatoryFirstName": {
+                    "type": "string",
+                    "maxLength": 30
+                },
+                "signatoryMiddleName": {
+                    "type": "string",
+                    "maxLength": 30
+                },
+                "signatoryLastName": {
+                    "type": "string",
+                    "maxLength": 30
                 }
             }
         }

--- a/src/registry_schemas/schemas/special_resolution.json
+++ b/src/registry_schemas/schemas/special_resolution.json
@@ -30,17 +30,8 @@
                     "type": "string",
                     "format": "date"
                 },
-                "signatoryFirstName": {
-                    "type": "string",
-                    "maxLength": 30
-                },
-                "signatoryMiddleName": {
-                    "type": "string",
-                    "maxLength": 30
-                },
-                "signatoryLastName": {
-                    "type": "string",
-                    "maxLength": 30
+                "signatory": {
+                    "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/person"
                 }
             }
         }

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.15.10'  # pylint: disable=invalid-name
+__version__ = '2.15.11'  # pylint: disable=invalid-name

--- a/tests/unit/schema_data.py
+++ b/tests/unit/schema_data.py
@@ -50,4 +50,5 @@ TEST_SCHEMAS_DATA = [
     ('todo.json'),
     ('transition.json'),
     ('unmanaged.json'),
+    ('person.json'),
 ]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8914

*Description of changes:*

* Update dissolution schema to no longer embed special resolution schema
* Remove document fields(`resolutionFileKey`, `resolutionFileName `) from special resolution schema
* Added person schema
* Add new fields(`resolutionDate`, `signingDate`, `signatory`) to special resolution schema.  Note: most validation will take place in the legal api to ensure previous schema data still conforms to schema definition.
* bump version number

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
