### PR TITLE
14052 Update max length of party organization name to 150

### DIFF
--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -819,7 +819,7 @@ DISSOLUTION = {
                 'firstName': '',
                 'lastName': '',
                 'middleName': '',
-                'organizationName': 'Xyz Inc.',
+                'organizationName': 'Xyz some super super super super super super long business 12345678 name Inc.',
                 'partyType': 'organization'
             },
             'mailingAddress': {

--- a/src/registry_schemas/schemas/party.json
+++ b/src/registry_schemas/schemas/party.json
@@ -29,7 +29,7 @@
                 },
                 "organizationName": {
                     "type": "string",
-                    "maxLength": 50
+                    "maxLength": 150
                 },
                 "identifier": {
                   "type": "string",

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.15.34'  # pylint: disable=invalid-name
+__version__ = '2.15.35'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14052

*Description of changes:*

* Update party schema organization name field to have max length of 150
* Updated schema data to use longer organization name
* Updated schema version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
