### PR TITLE
14120 Update first name and middle initial max length to 30

### DIFF
--- a/src/registry_schemas/schemas/party.json
+++ b/src/registry_schemas/schemas/party.json
@@ -17,7 +17,7 @@
                 },
                 "firstName": {
                     "type": "string",
-                    "maxLength": 20
+                    "maxLength": 30
                 },
                 "lastName": {
                     "type": "string",
@@ -25,7 +25,7 @@
                 },
                 "middleInitial": {
                     "type": "string",
-                    "maxLength": 20
+                    "maxLength": 30
                 },
                 "organizationName": {
                     "type": "string",

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.15.35'  # pylint: disable=invalid-name
+__version__ = '2.15.36'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14120

Note: A separate PR will be created to address required max length validation for first and middle name where the schema validation doesn't catch length requirements for legal types with different validation criteria.  i.e.  max first and middle name length validation for COOPs and  BENs where length cannot be greater than 20.

*Description of changes:*

* Update max length for firstName and middleInitial fields in party schema to 30

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
