### PR TITLE
14097 update address schema to be consistent

### DIFF
--- a/src/registry_schemas/schemas/address.json
+++ b/src/registry_schemas/schemas/address.json
@@ -10,7 +10,10 @@
             "maxLength": 50
         },
         "streetAddressAdditional": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "maxLength": 50
         },
         "addressCity": {
@@ -43,7 +46,6 @@
         "streetAddress",
         "addressCity",
         "addressCountry",
-        "postalCode",
-        "addressRegion"
+        "postalCode"
     ]
 }

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.15.36'  # pylint: disable=invalid-name
+__version__ = '2.15.37'  # pylint: disable=invalid-name

--- a/tests/unit/test_addresses.py
+++ b/tests/unit/test_addresses.py
@@ -17,6 +17,8 @@ This suite should have at least 1 test for every filing type allowed.
 """
 import copy
 
+import pytest
+
 from registry_schemas import validate
 from registry_schemas.example_data import ADDRESS
 
@@ -63,10 +65,16 @@ def test_invalid_address():
     assert not is_valid
 
 
-def test_invalid_address_missing_region():
+@pytest.mark.parametrize('field', [
+    'streetAddress',
+    'addressCity',
+    'addressCountry',
+    'postalCode'
+])
+def test_invalid_address_missing_field(field):
     """Assert that an invalid address fails - missing required field addressRegion."""
     address = copy.deepcopy(ADDRESS)
-    del address['addressRegion']
+    del address[field]
 
     is_valid, errors = validate(address, 'address')
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14097

*Description of changes:*
  - Remove `addressRegion` from required and allow null in `streetAddressAdditional`. Now `streetAddressAdditional`, `addressRegion` and `deliveryInstructions` can be null and can be optional

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
