### PR TITLE
14410 Update correction schema to include alterations to match changes in filing UI

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ pyhamcrest
 # Lint and code style
 isort<5,>=4.2.5
 pydocstyle<4
-flake8
+flake8==5.0.4
 flake8-blind-except
 flake8-debugger
 flake8-docstrings

--- a/src/registry_schemas/schemas/correction.json
+++ b/src/registry_schemas/schemas/correction.json
@@ -27,6 +27,7 @@
           "type": "string",
           "title": "The type of the main filing being corrected.",
           "enum": [
+            "alteration",
             "annualReport",
             "changeOfDirectors",
             "changeOfAddress",

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.15.38'  # pylint: disable=invalid-name
+__version__ = '2.15.39'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14410

*Description of changes:*
 - Make correction schema consistent with filing UI [`disableCorrection`](https://github.com/bcgov/business-filings-ui/blob/2379fa8d3bf0717b54fcbe1bba86c536c9a3b064/src/components/Dashboard/FilingHistoryList.vue#L879) & [`HistoryIF`](https://github.com/bcgov/business-filings-ui/blob/2379fa8d3bf0717b54fcbe1bba86c536c9a3b064/src/interfaces/history-item-interface.ts#L46)and allow alteration filings to be corrected.
 - Update set flake8 linter to last working version in requirements. Fix is also in [lear](https://github.com/bcgov/lear/blob/1c95139c4d79175ca152f283e3ab1defb85ef9a4/legal-api/requirements/dev.txt#L14)
 - Update version -> 2.15.39

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
