### PR TITLE
add legalName to restorations

### DIFF
--- a/src/registry_schemas/schemas/restoration.json
+++ b/src/registry_schemas/schemas/restoration.json
@@ -59,6 +59,10 @@
                         "registrar"
                     ]
                 },
+                "legalName": {
+                    "title": "The legal name of the entity at the time of the limited restoration",
+                    "type": "string"
+                },
                 "courtOrder": {
                     "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/court_order#/properties/courtOrder"
                 },


### PR DESCRIPTION
*Issue #:* /bcgov/entity14808

Add `legalName` attribute to the limited restoration schema.  The UI team has requested that the entity's name -- at the time of limited restoration -- is added to dashboard.  See screenshot below:

![image](https://user-images.githubusercontent.com/25233684/214977710-1ea6f06f-0b69-4186-ae85-514abc1ee154.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
