### PR TITLE
14672 Update approval type to be required field in restoration schema

### DIFF
--- a/src/registry_schemas/schemas/restoration.json
+++ b/src/registry_schemas/schemas/restoration.json
@@ -12,6 +12,7 @@
             "type": "object",
             "required": [
                 "type",
+                "approvalType",
                 "offices",
                 "parties",
                 "contactPoint"
@@ -49,6 +50,7 @@
                 "approvalType": {
                     "type": "string",
                     "title": "The Type of Approval, such as Approved by Court or Registrar.",
+                    "description": "In the case of a limited restoration extension or limited restoration to full filing, the approval type needs to the same value as the original limited restoration filing.",
                     "enum": [
                         "courtOrder",
                         "registrar"

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -23,4 +23,4 @@ Development release segment: .devN
 """
 
 
-__version__ = '2.18.4'  # pylint: disable=invalid-name
+__version__ = '2.18.5'  # pylint: disable=invalid-name

--- a/tests/unit/test_restoration.py
+++ b/tests/unit/test_restoration.py
@@ -93,7 +93,6 @@ def test_limited_restoration_extension():
     restoration_json = copy.deepcopy(RESTORATION)
     restoration_json['type'] = 'limitedRestorationExtension'
     restoration_json['expiry'] = '2023-01-18'
-    del restoration_json['approvalType']
     del restoration_json['nameRequest']
     del restoration_json['nameTranslations']
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14672

*Description of changes:*

* Update `approvalType` in restoration schema a required field.
* Update tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
