### PR TITLE
5530 legal name change related schema updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask
-jsonschema[format]
+jsonschema[format]==4.17.3
 requests
 strict-rfc3339

--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -37,6 +37,7 @@ FILING_HEADER = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'legalName': 'legal name - CP1234567',
+            'businessName': 'legal name - CP1234567',
             'legalType': 'CP'
         }
     }
@@ -49,6 +50,7 @@ BUSINESS = {
     'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
     'lastPreBobFilingTimestamp': '2019-04-15T20:05:49.068272+00:00',
     'legalName': 'legal name - CP1234567',
+    'businessName': 'legal name - CP1234567',
     'legalType': 'CP',
     'state': 'ACTIVE',
     'goodStanding': True,
@@ -70,6 +72,7 @@ BUSINESS_HISTORICAL = {
     'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
     'lastPreBobFilingTimestamp': '2019-04-15T20:05:49.068272+00:00',
     'legalName': 'legal name - CP1234567',
+    'businessName': 'legal name - CP1234567',
     'legalType': 'CP',
     'state': 'HISTORICAL',
     'stateFiling': 'https://LEGAL-API-HOST/api/v2/businesses/IDENTIFIER/filings/FILING_ID'
@@ -101,6 +104,7 @@ ANNUAL_REPORT = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
             'legalName': 'legal name - CP1234567',
+            'businessName': 'legal name - CP1234567',
             'legalType': 'CP'
         },
         'annualReport': {
@@ -374,6 +378,7 @@ CORRECTION_AR = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
             'legalName': 'legal name - CP1234567',
+            'businessName': 'legal name - CP1234567',
             'legalType': 'CP'
         },
         'correction': {
@@ -464,6 +469,7 @@ CORRECTION_COA = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
             'legalName': 'legal name - CP1234567',
+            'businessName': 'legal name - CP1234567',
             'legalType': 'CP'
         },
         'correction': {
@@ -518,6 +524,7 @@ CORRECTION_COD = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
             'legalName': 'legal name - CP1234567',
+            'businessName': 'legal name - CP1234567',
             'legalType': 'CP'
         },
         'correction': {
@@ -630,6 +637,7 @@ CORRECTION_COMBINED_AR = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
             'legalName': 'legal name - CP1234567',
+            'businessName': 'legal name - CP1234567',
             'legalType': 'CP'
         },
         'correction': {
@@ -1057,6 +1065,7 @@ CORRECTION_INCORPORATION = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
             'legalName': 'legal name - BC1234567',
+            'businessName': 'legal name - BC1234567',
             'legalType': 'BC'
         },
         'correction': {
@@ -1488,6 +1497,7 @@ CORRECTION_REGISTRATION = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
             'legalName': 'legal name - FM1234567',
+            'businessName': 'legal name - FM1234567',
             'legalType': 'GP'
         },
         'correction': {
@@ -1693,6 +1703,7 @@ CORRECTION_CHANGE_OF_REGISTRATION = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
             'legalName': 'legal name - FM1234567',
+            'businessName': 'legal name - FM1234567',
             'legalType': 'GP'
         },
         'correction': {
@@ -2363,6 +2374,7 @@ FILING_TEMPLATE = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'legalName': 'legal name - CP1234567',
+            'businessName': 'legal name - CP1234567',
             'legalType': 'CP'
         }
     }
@@ -2413,6 +2425,7 @@ ALTERATION_FILING_TEMPLATE = {
             'foundingDate': '2018-01-01T00:00:00+00:00',
             'identifier': 'U1234567',
             'legalName': 'legal name - Test',
+            'businessName': 'legal name - Test',
             'legalType': 'BC'
         },
         'alteration': ALTERATION
@@ -2433,6 +2446,7 @@ CONVERSION_FILING_TEMPLATE = {
             'identifier': 'BC1234567',
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'legalName': 'legal name - BC1234567',
+            'businessName': 'legal name - BC1234567',
             'legalType': 'BC'
         },
         'conversion': BEN_CONVERSION
@@ -2454,6 +2468,7 @@ TRANSITION_FILING_TEMPLATE = {
             'identifier': 'BC1234567',
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'legalName': 'legal name - BC1234567',
+            'businessName': 'legal name - BC1234567',
             'legalType': 'BC'
         },
         'transition': TRANSITION
@@ -2473,6 +2488,7 @@ REGISTRARS_NOTATION_FILING_TEMPLATE = {
             'foundingDate': '2018-01-01T00:00:00+00:00',
             'identifier': 'U1234567',
             'legalName': 'legal name - Test',
+            'businessName': 'legal name - Test',
             'legalType': 'BC'
         },
         'registrarsNotation': REGISTRARS_NOTATION
@@ -2492,6 +2508,7 @@ REGISTRARS_ORDER_FILING_TEMPLATE = {
             'foundingDate': '2018-01-01T00:00:00+00:00',
             'identifier': 'U1234567',
             'legalName': 'legal name - Test',
+            'businessName': 'legal name - Test',
             'legalType': 'BC'
         },
         'registrarsOrder': REGISTRARS_ORDER
@@ -2511,6 +2528,7 @@ COURT_ORDER_FILING_TEMPLATE = {
             'foundingDate': '2018-01-01T00:00:00+00:00',
             'identifier': 'U1234567',
             'legalName': 'legal name - Test',
+            'businessName': 'legal name - Test',
             'legalType': 'BC'
         },
         'courtOrder': COURT_ORDER
@@ -2530,6 +2548,7 @@ CHANGE_OF_REGISTRATION_TEMPLATE = {
             'foundingDate': '2018-01-01T00:00:00+00:00',
             'identifier': 'FM1234567',
             'legalName': 'legal name - Test',
+            'businessName': 'legal name - Test',
             'legalType': 'GP'
         },
         'changeOfRegistration': CHANGE_OF_REGISTRATION
@@ -2555,6 +2574,7 @@ CP_SPECIAL_RESOLUTION_TEMPLATE = {
             'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
             'lastPreBobFilingTimestamp': '2019-01-01T20:05:49.068272+00:00',
             'legalName': 'legal name - CP1234567',
+            'businessName': 'legal name - CP1234567',
             'legalType': 'CP'
         },
         'changeOfName': {

--- a/src/registry_schemas/schemas/business.json
+++ b/src/registry_schemas/schemas/business.json
@@ -14,9 +14,16 @@
     },
     "legalName": {
       "type": "string",
-      "title": "The Legal_name Schema",
+      "title": "The Legal Name of the business.",
       "default": "",
       "examples": ["legal_name"],
+      "pattern": "^(.*)$"
+    },
+    "businessName": {
+      "type": "string",
+      "title": "The business name of the business.  For firms, this will be the same as the operating name.  For other business legal types, this will likely be the same as the legal name.",
+      "default": "",
+      "examples": ["business_name"],
       "pattern": "^(.*)$"
     },
     "legalType": {
@@ -150,6 +157,9 @@
         },
         "legalName": {
           "$ref": "#/definitions/legalName"
+        },
+        "businessName": {
+          "$ref": "#/definitions/businessName"
         },
         "legalType": {
           "$ref": "#/definitions/legalType"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#5530

Note: this will be merged into a feature branch for legal name changes to isolate legal name specific changes from main branch.

*Description of changes:*

* Added `businessName` field to business schema.  This will make it easier for FE & API consumers to just reference one field to retrieve the name the business is using to do business.  For firms, this will be the operating name and for other business types this is the legal name.
* Added `businessName` to business block of various schema example data templates
* Pinned down jsonschema version to 4.17.3 as tests fail otherwise.  4.18.0 actually passes tests but fails linter so needed to use 4.17.3


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
