### PR TITLE
Organizations cannot be Directors. Changed to being the Completing Party

### DIFF
--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -2030,7 +2030,7 @@ TRANSITION = {
             },
             'roles': [
                 {
-                    'roleType': 'Director',
+                    'roleType': 'Completing Party',
                     'appointmentDate': '2018-01-01'
                 }
             ]


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18044

*Description of changes:*
- Organizations cannot be Directors. Changed to being the Completing Party


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
