### PR TITLE
17941 add agm_location_change_schema

### DIFF
--- a/src/registry_schemas/example_data/__init__.py
+++ b/src/registry_schemas/example_data/__init__.py
@@ -20,6 +20,7 @@ from .business_documents import COGS, CSTAT, LSEAL, SUMMARY
 from .schema_data import (
     ADDRESS,
     ADMIN_FREEZE,
+    AGM_LOCATION_CHANGE,
     ALL_FILINGS,
     ALTERATION,
     ALTERATION_FILING_TEMPLATE,

--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -2701,6 +2701,19 @@ ADMIN_FREEZE = {
     'freeze': True
 }
 
+AGM_LOCATION_CHANGE = {
+    'year': '2023',
+    'newAgmLocation': {
+        'streetAddress': 'mailing_address - address line one',
+        'streetAddressAdditional': '',
+        'addressCity': 'mailing_address city',
+        'addressCountry': 'CA',
+        'postalCode': 'H0H0H0',
+        'addressRegion': 'BC',
+        'additionalLocationDetails': ''
+    }
+}
+
 # build complete list of filings with names, for use in the generic test_valid_filing() test
 # - not including AR or correction because they are already complete filings rather than the others that are snippets
 # without header and business elements; prepended to list afterwards.

--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -2710,7 +2710,7 @@ AGM_LOCATION_CHANGE = {
         'addressCountry': 'CA',
         'postalCode': 'H0H0H0',
         'addressRegion': 'ON',
-        'additionalLocationDetails': ''
+        'deliveryInstructions': ''
     }
 }
 

--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -2709,7 +2709,7 @@ AGM_LOCATION_CHANGE = {
         'addressCity': 'mailing_address city',
         'addressCountry': 'CA',
         'postalCode': 'H0H0H0',
-        'addressRegion': 'BC',
+        'addressRegion': 'ON',
         'additionalLocationDetails': ''
     }
 }

--- a/src/registry_schemas/schemas/agm_location_change.json
+++ b/src/registry_schemas/schemas/agm_location_change.json
@@ -20,23 +20,7 @@
                     "description": "Year of the AGM, Must be on or after incorporation year and cannot be future year."
                 },
                 "newAgmLocation": {
-                    "allOf": [
-                        { "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/address" },
-                        {
-                            "properties": {
-                                "additionalLocationDetails": {
-                                    "type": ["string", "null"],
-                                    "maxLength": 2000
-                                }
-                            },
-                            "required": [
-                                "streetAddress",
-                                "addressCity",
-                                "addressCountry",
-                                "addressRegion",
-                                "postalCode"
-                            ]
-                        }]
+                    "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/address"
                 }
             }
         }

--- a/src/registry_schemas/schemas/agm_location_change.json
+++ b/src/registry_schemas/schemas/agm_location_change.json
@@ -46,12 +46,10 @@
                             "maxLength": 40
                         },
                         "addressCountry": {
-                            "type": "string",
-                            "enum": ["Canada", "CA"]
+                            "type": "string"
                         },
                         "addressRegion": {
                             "type": "string",
-                            "enum": ["BC"],
                             "description": "Must be in B.C."
                         },
                         "postalCode": {

--- a/src/registry_schemas/schemas/agm_location_change.json
+++ b/src/registry_schemas/schemas/agm_location_change.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/agm_location_change",
+    "type": "object",
+    "definitions": {},
+    "title": "AGM Location Change Information Schema",
+    "required": [
+        "agmLocationChange"
+    ],
+    "properties": {
+        "agmLocationChange": {
+            "type": "object",
+            "required": [
+                "year",
+                "newAgmLocation"
+            ],
+            "properties": {
+                "year": {
+                    "type": "string",
+                    "description": "Year of the AGM, Must be on or after incorporation year and cannot be future year."
+                },
+                "newAgmLocation": {
+                    "type": "object",
+                    "description": "New AGM Location, Must be in B.C.",
+                    "required": [
+                        "streetAddress",
+                        "addressCity",
+                        "addressCountry",
+                        "addressRegion",
+                        "postalCode"
+                    ],
+                    "properties": {
+                        "streetAddress": {
+                            "type": "string",
+                            "maxLength": 50
+                        },
+                        "streetAddressAdditional": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 50
+                        },
+                        "addressCity": {
+                            "type": "string",
+                            "maxLength": 40
+                        },
+                        "addressCountry": {
+                            "type": "string",
+                            "enum": ["Canada", "CA"]
+                        },
+                        "addressRegion": {
+                            "type": "string",
+                            "enum": ["BC"],
+                            "description": "Must be in B.C."
+                        },
+                        "postalCode": {
+                            "type": "string",
+                            "maxLength": 15
+                        },
+                        "additionalLocationDetails": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 2000
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/registry_schemas/schemas/agm_location_change.json
+++ b/src/registry_schemas/schemas/agm_location_change.json
@@ -21,7 +21,7 @@
                 },
                 "newAgmLocation": {
                     "type": "object",
-                    "description": "New AGM Location, Must be in B.C.",
+                    "description": "The AGM location change detail",
                     "required": [
                         "streetAddress",
                         "addressCity",

--- a/src/registry_schemas/schemas/agm_location_change.json
+++ b/src/registry_schemas/schemas/agm_location_change.json
@@ -49,8 +49,11 @@
                             "type": "string"
                         },
                         "addressRegion": {
-                            "type": "string",
-                            "description": "Must be in B.C."
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 2
                         },
                         "postalCode": {
                             "type": "string",

--- a/src/registry_schemas/schemas/agm_location_change.json
+++ b/src/registry_schemas/schemas/agm_location_change.json
@@ -20,53 +20,16 @@
                     "description": "Year of the AGM, Must be on or after incorporation year and cannot be future year."
                 },
                 "newAgmLocation": {
-                    "type": "object",
-                    "description": "The AGM location change detail",
-                    "required": [
-                        "streetAddress",
-                        "addressCity",
-                        "addressCountry",
-                        "addressRegion",
-                        "postalCode"
-                    ],
-                    "properties": {
-                        "streetAddress": {
-                            "type": "string",
-                            "maxLength": 50
-                        },
-                        "streetAddressAdditional": {
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "maxLength": 50
-                        },
-                        "addressCity": {
-                            "type": "string",
-                            "maxLength": 40
-                        },
-                        "addressCountry": {
-                            "type": "string"
-                        },
-                        "addressRegion": {
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "maxLength": 2
-                        },
-                        "postalCode": {
-                            "type": "string",
-                            "maxLength": 15
-                        },
-                        "additionalLocationDetails": {
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "maxLength": 2000
-                        }
-                    }
+                    "allOf": [
+                        { "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/address" },
+                        {
+                            "properties": {
+                                "additionalLocationDetails": {
+                                    "type": ["string", "null"],
+                                    "maxLength": 2000
+                                }
+                            }
+                        }]
                 }
             }
         }

--- a/src/registry_schemas/schemas/agm_location_change.json
+++ b/src/registry_schemas/schemas/agm_location_change.json
@@ -28,7 +28,14 @@
                                     "type": ["string", "null"],
                                     "maxLength": 2000
                                 }
-                            }
+                            },
+                            "required": [
+                                "streetAddress",
+                                "addressCity",
+                                "addressCountry",
+                                "addressRegion",
+                                "postalCode"
+                            ]
                         }]
                 }
             }

--- a/src/registry_schemas/schemas/filing.json
+++ b/src/registry_schemas/schemas/filing.json
@@ -47,6 +47,7 @@
               "enum": [
                 "adminFreeze",
                 "alteration",
+                "agmLocationChange",
                 "amalgamationApplication",
                 "amendedAGM",
                 "amendedAnnualReport",
@@ -236,6 +237,9 @@
       "anyOf": [
         {
           "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/admin_freeze"
+        },
+        {
+          "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/agm_location_change"
         },
         {
           "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/alteration"

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -23,4 +23,4 @@ Development release segment: .devN
 """
 
 
-__version__ = '2.18.11'  # pylint: disable=invalid-name
+__version__ = '2.18.12'  # pylint: disable=invalid-name

--- a/tests/unit/schema_data.py
+++ b/tests/unit/schema_data.py
@@ -19,6 +19,7 @@ Test array used in multiple pytests, and several filings that can be used in tes
 TEST_SCHEMAS_DATA = [
     ('address.json'),
     ('admin_freeze.json'),
+    ('agm_location_change.json'),
     ('affiliated_businesses.json'),
     ('agreement_type.json'),
     ('alteration.json'),

--- a/tests/unit/test_agm_location_change.py
+++ b/tests/unit/test_agm_location_change.py
@@ -78,19 +78,3 @@ def test_validate_no_agm_address():
     print(errors)
 
     assert not is_valid
-
-
-def test_validate_no_agm_address():
-    """Assert that an addressRegion node is present in the agm location change."""
-    agm_location_change = copy.deepcopy(AGM_LOCATION_CHANGE)
-    alc_json = {'agmLocationChange': agm_location_change}
-    del alc_json['agmLocationChange']['newAgmLocation']['addressRegion']
-
-    is_valid, errors = validate(alc_json, 'agm_location_change')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
-
-    assert not is_valid

--- a/tests/unit/test_agm_location_change.py
+++ b/tests/unit/test_agm_location_change.py
@@ -78,3 +78,19 @@ def test_validate_no_agm_address():
     print(errors)
 
     assert not is_valid
+
+
+def test_validate_no_agm_address():
+    """Assert that an addressRegion node is present in the agm location change."""
+    agm_location_change = copy.deepcopy(AGM_LOCATION_CHANGE)
+    alc_json = {'agmLocationChange': agm_location_change}
+    del alc_json['agmLocationChange']['newAgmLocation']['addressRegion']
+
+    is_valid, errors = validate(alc_json, 'agm_location_change')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert not is_valid

--- a/tests/unit/test_agm_location_change.py
+++ b/tests/unit/test_agm_location_change.py
@@ -1,0 +1,61 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test Suite to ensure agm location change schemas are valid."""
+from registry_schemas import validate
+from registry_schemas.example_data import AGM_LOCATION_CHANGE
+
+
+def test_agm_location_change_schema():
+    """Assert that the JSONSchema validator is working."""
+    alc_json = {'agmLocationChange': AGM_LOCATION_CHANGE}
+
+    is_valid, errors = validate(alc_json, 'agm_location_change')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert is_valid
+
+
+def test_validate_no_agm_year():
+    """Assert that an offices node is present in the Annual Report."""
+    alc_json = {'agmLocationChange': AGM_LOCATION_CHANGE}
+    del alc_json['agmLocationChange']['year']
+
+    is_valid, errors = validate(alc_json, 'agm_location_change')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert not is_valid
+
+def test_validate_no_BC():
+    """Assert that an offices node is present in the Annual Report."""
+    alc_json = {'agmLocationChange': AGM_LOCATION_CHANGE}
+    alc_json['agmLocationChange']['newAgmLocation']['addressRegion'] = 'ON'
+
+    updated_alc_json = alc_json
+
+    is_valid, errors = validate(updated_alc_json, 'agm_location_change')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert not is_valid

--- a/tests/unit/test_agm_location_change.py
+++ b/tests/unit/test_agm_location_change.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test Suite to ensure agm location change schemas are valid."""
+import copy
 from registry_schemas import validate
 from registry_schemas.example_data import AGM_LOCATION_CHANGE
 
 
 def test_agm_location_change_schema():
     """Assert that the JSONSchema validator is working."""
-    alc_json = {'agmLocationChange': AGM_LOCATION_CHANGE}
+    agm_location_change = copy.deepcopy(AGM_LOCATION_CHANGE)
+    alc_json = {'agmLocationChange': copy.deepcopy(agm_location_change)}
 
     is_valid, errors = validate(alc_json, 'agm_location_change')
 
@@ -32,8 +34,41 @@ def test_agm_location_change_schema():
 
 def test_validate_no_agm_year():
     """Assert that an year node is present in the agm location change."""
-    alc_json = {'agmLocationChange': AGM_LOCATION_CHANGE}
+    agm_location_change = copy.deepcopy(AGM_LOCATION_CHANGE)
+    alc_json = {'agmLocationChange': agm_location_change}
     del alc_json['agmLocationChange']['year']
+
+    is_valid, errors = validate(alc_json, 'agm_location_change')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert not is_valid
+
+
+def test_validate_no_agm_location():
+    """Assert that an newAgmLocation node is present in the agm location change."""
+    agm_location_change = copy.deepcopy(AGM_LOCATION_CHANGE)
+    alc_json = {'agmLocationChange': agm_location_change}
+    del alc_json['agmLocationChange']['newAgmLocation']
+
+    is_valid, errors = validate(alc_json, 'agm_location_change')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert not is_valid
+
+
+def test_validate_no_agm_address():
+    """Assert that an streetAddress node is present in the agm location change."""
+    agm_location_change = copy.deepcopy(AGM_LOCATION_CHANGE)
+    alc_json = {'agmLocationChange': agm_location_change}
+    del alc_json['agmLocationChange']['newAgmLocation']['streetAddress']
 
     is_valid, errors = validate(alc_json, 'agm_location_change')
 

--- a/tests/unit/test_agm_location_change.py
+++ b/tests/unit/test_agm_location_change.py
@@ -31,7 +31,7 @@ def test_agm_location_change_schema():
 
 
 def test_validate_no_agm_year():
-    """Assert that an offices node is present in the Annual Report."""
+    """Assert that an year node is present in the agm location change."""
     alc_json = {'agmLocationChange': AGM_LOCATION_CHANGE}
     del alc_json['agmLocationChange']['year']
 
@@ -44,8 +44,8 @@ def test_validate_no_agm_year():
 
     assert not is_valid
 
-def test_validate_no_BC():
-    """Assert that an offices node is present in the Annual Report."""
+def test_validate_not_BC():
+    """Assert that an address region node is BC in the agm location change."""
     alc_json = {'agmLocationChange': AGM_LOCATION_CHANGE}
     alc_json['agmLocationChange']['newAgmLocation']['addressRegion'] = 'ON'
 

--- a/tests/unit/test_agm_location_change.py
+++ b/tests/unit/test_agm_location_change.py
@@ -43,19 +43,3 @@ def test_validate_no_agm_year():
     print(errors)
 
     assert not is_valid
-
-def test_validate_not_BC():
-    """Assert that an address region node is BC in the agm location change."""
-    alc_json = {'agmLocationChange': AGM_LOCATION_CHANGE}
-    alc_json['agmLocationChange']['newAgmLocation']['addressRegion'] = 'ON'
-
-    updated_alc_json = alc_json
-
-    is_valid, errors = validate(updated_alc_json, 'agm_location_change')
-
-    if errors:
-        for err in errors:
-            print(err.message)
-    print(errors)
-
-    assert not is_valid


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17941

*Description of changes:*

Add AGM_Location_change Schema

- existing deliveryInstructions field in address schema will be used for additionalLocationDetails
	
- required addressRegion validation will be done in the legal api validators to avoid needing to overriding existing address schema validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
