### PR TITLE
Add required fields for AGM extension

### DIFF
--- a/src/registry_schemas/schemas/agm_extension.json
+++ b/src/registry_schemas/schemas/agm_extension.json
@@ -11,7 +11,9 @@
         "agmExtension": {
             "type": "object",
             "required": [
-                "year", "isFirstAgm", "extReqForAgmYear"
+                "year",
+                "isFirstAgm",
+                "extReqForAgmYear"
             ],
             "properties": {
                 "year": {

--- a/src/registry_schemas/schemas/agm_extension.json
+++ b/src/registry_schemas/schemas/agm_extension.json
@@ -11,7 +11,7 @@
         "agmExtension": {
             "type": "object",
             "required": [
-                "year"
+                "year", "isFirstAgm", "extReqForAgmYear"
             ],
             "properties": {
                 "year": {

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -23,4 +23,4 @@ Development release segment: .devN
 """
 
 
-__version__ = '2.18.15'  # pylint: disable=invalid-name
+__version__ = '2.18.16'  # pylint: disable=invalid-name

--- a/tests/unit/test_agm_extension.py
+++ b/tests/unit/test_agm_extension.py
@@ -46,3 +46,35 @@ def test_validate_no_agm_year():
     print(errors)
 
     assert not is_valid
+
+
+def test_validate_no_is_first_agm():
+    """Assert that an isFirstAgm node is present in the agm extension."""
+    agm_extension = copy.deepcopy(AGM_EXTENSION)
+    ale_json = {'agmExtension': agm_extension}
+    del ale_json['agmExtension']['isFirstAgm']
+
+    is_valid, errors = validate(ale_json, 'agm_extension')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert not is_valid
+
+
+def test_validate_no_ext_req_for_agm_year():
+    """Assert that an extReqForAgmYear node is present in the agm extension."""
+    agm_extension = copy.deepcopy(AGM_EXTENSION)
+    ale_json = {'agmExtension': agm_extension}
+    del ale_json['agmExtension']['extReqForAgmYear']
+
+    is_valid, errors = validate(ale_json, 'agm_extension')
+
+    if errors:
+        for err in errors:
+            print(err.message)
+    print(errors)
+
+    assert not is_valid


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18053

*Description of changes:*
- `isFirstAgm` and `extReqForAgmYear` should always exist under different scenarios, so add them into required fields 
- version = 2.18.16

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
