### PR TITLE
Add missed field for AGM Extension

### DIFF
--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -2715,6 +2715,7 @@ AGM_EXTENSION = {
     'expireDateCurrExt': '2023-10-10',
     'intendedAgmDate': '2023-10-10',
     'totalApprovedExt': 12,
+    'extensionDuration': 6,
     'expireDateApprovedExt': '2023-10-10'
 }
 

--- a/src/registry_schemas/schemas/agm_extension.json
+++ b/src/registry_schemas/schemas/agm_extension.json
@@ -56,6 +56,10 @@
                     "type": "integer",
                     "description": "Total duration of extension approved, measured in months."
                 },
+                "extensionDuration": {
+                    "type": "integer",
+                    "description": "Duration of extension approved for this request, measured in months."
+                },
                 "expireDateApprovedExt":{
                     "type": "string",
                     "format": "date",

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -23,4 +23,4 @@ Development release segment: .devN
 """
 
 
-__version__ = '2.18.16'  # pylint: disable=invalid-name
+__version__ = '2.18.17'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18723

*Description of changes:*
- Added a missed field `extensionDuration` for AGM extension

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
