### PR TITLE
28475 increase streetAddressAdditional max length to 105 to support migration of COLIN data

### DIFF
--- a/src/registry_schemas/schemas/address.json
+++ b/src/registry_schemas/schemas/address.json
@@ -14,7 +14,7 @@
                 "string",
                 "null"
             ],
-            "maxLength": 50
+            "maxLength": 105
         },
         "addressCity": {
             "type": "string",

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -23,4 +23,4 @@ Development release segment: .devN
 """
 
 
-__version__ = '2.18.45'  # pylint: disable=invalid-name
+__version__ = '2.18.46'  # pylint: disable=invalid-name

--- a/tests/unit/test_addresses.py
+++ b/tests/unit/test_addresses.py
@@ -50,10 +50,15 @@ def test_valid_address_null_region():
     assert is_valid
 
 
-def test_invalid_address():
+@pytest.mark.parametrize('field,value', [
+    ('streetAddress', 'This is a really long string, over the 50 char maximum'),
+    ('streetAddressAdditional', 
+     'This is a really long string, over the maximum limit (105 char), which should cause the validation to fail.')
+])
+def test_invalid_address(field, value):
     """Assert that an invalid address fails."""
     address = copy.deepcopy(ADDRESS)
-    address['streetAddress'] = 'This is a really long string, over the 50 char maximum'
+    address[field] = value
 
     is_valid, errors = validate(address, 'address')
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28475

*Description of changes:*
  - In migration we join (addr_line_2 + ' ' + addr_line_3) to update `streetAdditional`. In Colin we have data in addr_line_2 and addr_line_3 with length of 50 respectively 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
