### PR TITLE
30849 - feat: Add courtOrder schema reference to transition.json

### DIFF
--- a/src/registry_schemas/schemas/transition.json
+++ b/src/registry_schemas/schemas/transition.json
@@ -49,6 +49,9 @@
         },
         "contactPoint": {
           "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/contactPoint"
+        },
+        "courtOrder": {
+          "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/court_order#/properties/courtOrder"
         }
       }
     }


### PR DESCRIPTION
*Issue #:30849 * /bcgov/entity#30849 

*Description of changes:*
- Add courtOrder schema reference to transition.json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
