### PR TITLE
32826 - Add authorizationReceived to Filing Schema

### DIFF
--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -2812,7 +2812,7 @@ TRANSITION_FILING_TEMPLATE = {
             'name': 'transition',
             'date': '2020-10-19',
             'certifiedBy': 'full name',
-            'authorizationReceived': True,            
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1,
             'paymentAccount': '746'
@@ -2854,7 +2854,7 @@ REGISTRARS_ORDER_FILING_TEMPLATE = {
             'name': 'registrarsOrder',
             'date': '2021-05-06',
             'certifiedBy': 'full name',
-            'authorizationReceived': True,            
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1
         },
@@ -2874,7 +2874,7 @@ COURT_ORDER_FILING_TEMPLATE = {
             'name': 'courtOrder',
             'date': '2021-05-06',
             'certifiedBy': 'full name',
-            'authorizationReceived': True,            
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1
         },
@@ -2894,7 +2894,7 @@ CHANGE_OF_REGISTRATION_TEMPLATE = {
             'name': 'changeOfRegistration',
             'date': '2021-05-06',
             'certifiedBy': 'full name',
-            'authorizationReceived': True,            
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1
         },
@@ -2914,7 +2914,7 @@ CP_SPECIAL_RESOLUTION_TEMPLATE = {
             'name': 'specialResolution',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
-            'authorizationReceived': True,            
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'routingSlipNumber': '123456789',

--- a/src/registry_schemas/example_data/schema_data.py
+++ b/src/registry_schemas/example_data/schema_data.py
@@ -24,6 +24,7 @@ FILING_HEADER = {
             'inColinOnly': False,
             'date': '2019-04-08',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1,
             'routingSlipNumber': '123456789',
@@ -263,6 +264,7 @@ ANNUAL_REPORT = {
             'name': 'annualReport',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2019-04-08'
         },
@@ -790,6 +792,7 @@ CORRECTION_AR = {
             'name': 'correction',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'affectedFilings': [101, ],
@@ -819,6 +822,7 @@ CORRECTION_COA = {
             'name': 'correction',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'routingSlipNumber': '123456789',
@@ -875,6 +879,7 @@ CORRECTION_COL = {
             'name': 'correction',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'routingSlipNumber': '123456789'
@@ -936,6 +941,7 @@ CORRECTION_COR = {
             'name': 'correction',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'routingSlipNumber': '123456789'
@@ -997,6 +1003,7 @@ CORRECTION_COMBINED_AR = {
             'name': 'correction',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'routingSlipNumber': '123456789'
@@ -1425,6 +1432,7 @@ CORRECTION_INCORPORATION = {
             'name': 'correction',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'routingSlipNumber': '123456789'
@@ -1847,6 +1855,7 @@ CORRECTION_REGISTRATION = {
             'name': 'correction',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'routingSlipNumber': '123456789'
@@ -2052,6 +2061,7 @@ CORRECTION_CHANGE_OF_REGISTRATION = {
             'name': 'correction',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'routingSlipNumber': '123456789'
@@ -2704,6 +2714,7 @@ FILING_TEMPLATE = {
             'name': None,
             'date': '2019-04-08',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1,
             'effectiveDate': '2019-04-15T00:00:00+00:00'
@@ -2726,6 +2737,7 @@ INCORPORATION_FILING_TEMPLATE = {
             'name': 'incorporationApplication',
             'date': '2019-04-08',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1,
             'effectiveDate': '2019-04-15T00:00:00+00:00'
@@ -2744,6 +2756,7 @@ CONTINUATION_IN_FILING_TEMPLATE = {
             'name': 'continuationIn',
             'date': '2019-04-08',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1,
             'effectiveDate': '2019-04-15T00:00:00+00:00'
@@ -2758,6 +2771,7 @@ ALTERATION_FILING_TEMPLATE = {
             'name': 'alteration',
             'date': '2020-06-25',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1
         },
@@ -2777,6 +2791,7 @@ CONVERSION_FILING_TEMPLATE = {
             'name': 'conversion',
             'date': '2020-06-25',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1
         },
@@ -2797,6 +2812,7 @@ TRANSITION_FILING_TEMPLATE = {
             'name': 'transition',
             'date': '2020-10-19',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,            
             'email': 'no_one@never.get',
             'filingId': 1,
             'paymentAccount': '746'
@@ -2818,6 +2834,7 @@ REGISTRARS_NOTATION_FILING_TEMPLATE = {
             'name': 'registrarsNotation',
             'date': '2021-05-06',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,
             'email': 'no_one@never.get',
             'filingId': 1
         },
@@ -2837,6 +2854,7 @@ REGISTRARS_ORDER_FILING_TEMPLATE = {
             'name': 'registrarsOrder',
             'date': '2021-05-06',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,            
             'email': 'no_one@never.get',
             'filingId': 1
         },
@@ -2856,6 +2874,7 @@ COURT_ORDER_FILING_TEMPLATE = {
             'name': 'courtOrder',
             'date': '2021-05-06',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,            
             'email': 'no_one@never.get',
             'filingId': 1
         },
@@ -2875,6 +2894,7 @@ CHANGE_OF_REGISTRATION_TEMPLATE = {
             'name': 'changeOfRegistration',
             'date': '2021-05-06',
             'certifiedBy': 'full name',
+            'authorizationReceived': True,            
             'email': 'no_one@never.get',
             'filingId': 1
         },
@@ -2894,6 +2914,7 @@ CP_SPECIAL_RESOLUTION_TEMPLATE = {
             'name': 'specialResolution',
             'availableOnPaperOnly': False,
             'certifiedBy': 'full name',
+            'authorizationReceived': True,            
             'email': 'no_one@never.get',
             'date': '2020-02-18',
             'routingSlipNumber': '123456789',

--- a/src/registry_schemas/schemas/filing.json
+++ b/src/registry_schemas/schemas/filing.json
@@ -213,6 +213,10 @@
               "type": "string",
               "title": "The type (legality) of this filing.",
               "enum": ["LEGAL", "NON_LEGAL", "INFO"]
+            },
+            "authorizationReceived": {
+                "type": "boolean",
+                "description": "Indicates the client has authorized the filing submission."
             }
           }
         }

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -23,4 +23,4 @@ Development release segment: .devN
 """
 
 
-__version__ = '2.18.66'  # pylint: disable=invalid-name
+__version__ = '2.18.67'  # pylint: disable=invalid-name

--- a/tests/unit/test_filings.py
+++ b/tests/unit/test_filings.py
@@ -363,6 +363,45 @@ def test_effective_date():
 
     assert not is_valid
 
+def test_authorization_received():
+    """Assert that authorization received validation works as expected."""
+    iar = {
+            'filing': {
+                'header': {
+                    'name': 'changeOfAddress',
+                    'date': '2019-04-08',
+                    'certifiedBy': 'full legal name',
+                    'email': 'no_one@never.get'
+                },
+                'business': {
+                    'cacheId': 1,
+                    'foundingDate': '2007-04-08T20:05:49.068272+00:00',
+                    'identifier': 'CP1234567',
+                    'lastLedgerTimestamp': '2019-04-15T20:05:49.068272+00:00',
+                    'legalName': 'legal name - CP1234567'
+                },
+                'changeOfAddress': CORP_CHANGE_OF_ADDRESS
+            }
+        }
+
+    is_valid, errors = validate(iar, 'filing')
+    assert is_valid
+
+    iar['filing']['header']['authorizationReceived'] = False
+    is_valid, errors = validate(iar, 'filing')
+    assert is_valid
+
+    iar['filing']['header']['authorizationReceived'] = True
+    is_valid, errors = validate(iar, 'filing')
+    assert is_valid
+
+    iar['filing']['header']['authorizationReceived'] = 'junk'
+    is_valid, errors = validate(iar, 'filing')
+    if errors:
+        for err in errors:
+            print(err.message)
+    assert not is_valid
+
 
 def test_incorporation_filing_schema():
     """Assert that the JSONSchema validator is working."""


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32826 

*Description of changes:*
Adding `authorizationReceived` boolean to the filing header to address the discrepancy between UI and API users — the UI requires an authorization checkbox but the API has no equivalent. API will enforce this for CORPS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
