### PR TITLE
33605 amalg schema - foreign legal name validation

### DIFF
--- a/src/registry_schemas/schemas/amalgamation_application.json
+++ b/src/registry_schemas/schemas/amalgamation_application.json
@@ -58,7 +58,8 @@
                             "foreignJurisdiction": {
                                 "properties": {
                                     "legalName": {
-                                        "minLength": 1
+                                        "minLength": 3,
+                                        "maxLength": 150
                                     }
                                 },
                                 "required": ["legalName"]

--- a/src/registry_schemas/schemas/amalgamation_application.json
+++ b/src/registry_schemas/schemas/amalgamation_application.json
@@ -55,12 +55,17 @@
                             }
                         },
                         "dependencies": {
-                            "foreignJurisdiction": [
-                                "legalName"
-                            ],
-                            "legalName": [
-                                "foreignJurisdiction"
-                            ]
+                            "foreignJurisdiction": {
+                                "properties": {
+                                    "legalName": {
+                                        "minLength": 1
+                                    }
+                                },
+                                "required": ["legalName"]
+                            },
+                            "legalName": {
+                                "required": ["foreignJurisdiction"]
+                            }
                         }
                     }
                 },

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -23,4 +23,4 @@ Development release segment: .devN
 """
 
 
-__version__ = '2.18.70'  # pylint: disable=invalid-name
+__version__ = '2.18.71'  # pylint: disable=invalid-name

--- a/tests/unit/test_amalgamation_application.py
+++ b/tests/unit/test_amalgamation_application.py
@@ -67,15 +67,19 @@ def test_amalgamation_schema_no_amalgamating_businesses():
     assert not is_valid
 
 
-@pytest.mark.parametrize('element', [
-    ('legalName'),
-    ('foreignJurisdiction'),
+@pytest.mark.parametrize('element,value', [
+    ('legalName','removed'),
+    ('legalName',''),
+    ('foreignJurisdiction','removed'),
 ])
-def test_amalgamation_schema_not_valid_foreign(element):
-    """Assert not valid if one of the field is not present."""
+def test_amalgamation_schema_not_valid_foreign(element, value):
+    """Assert not valid if one of the field is not present or invalid."""
     amalgamation = copy.deepcopy(AMALGAMATION_APPLICATION)
     aml_json = {'amalgamationApplication': amalgamation}
-    del aml_json['amalgamationApplication']['amalgamatingBusinesses'][1][element]
+    if value == 'removed':
+        del aml_json['amalgamationApplication']['amalgamatingBusinesses'][1][element]
+    else:
+        aml_json['amalgamationApplication']['amalgamatingBusinesses'][1][element] = value
 
     is_valid, errors = validate(aml_json, 'amalgamation_application')
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33605

*Description of changes:*
add min/max length to legal name validation when it is required due to foreign jurisdiction so that this comment holds true in the legal-api validation for legal name when its an empty string: https://github.com/bcgov/lear/blob/8c981127646178014efcfdb5fdd111cb8ce3ee7b/legal-api/src/legal_api/services/filings/validations/amalgamation_application.py#L198

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
