### PR TITLE
34022-director-mailingaddress-required

### DIFF
--- a/src/registry_schemas/schemas/directors.json
+++ b/src/registry_schemas/schemas/directors.json
@@ -72,6 +72,7 @@
             "required": [
                 "officer",
                 "deliveryAddress",
+                "mailingAddress",
                 "appointmentDate",
                 "cessationDate"
             ]

--- a/src/registry_schemas/version.py
+++ b/src/registry_schemas/version.py
@@ -23,4 +23,4 @@ Development release segment: .devN
 """
 
 
-__version__ = '2.18.73'  # pylint: disable=invalid-name
+__version__ = '2.18.74'  # pylint: disable=invalid-name


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34022

*Description of changes:*
Added "mailingAddress" to the director required array in directors.json (bumping registry_schemas to 2.18.74) so mailing-address presence is enforced at the schema level for all entity types instead of only CORPS in legal-api.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-schemas license (Apache 2.0).
